### PR TITLE
SavedImage supports extra params

### DIFF
--- a/blitline-image-client/src/test/java/com/blitline/image/functions/TestSerializer.java
+++ b/blitline-image-client/src/test/java/com/blitline/image/functions/TestSerializer.java
@@ -47,6 +47,9 @@ public class TestSerializer {
 			.toS3(S3Location.of("my-bucket-name", "abcd1234random.jpg"));
 		System.out.println(mapper.writeValueAsString(save));
 
+		save = SavedImage.withId("extraparams").withQuality(90).withParam("png_quantize", true).withParam("extension", ".png").toAzure(AzureLocation.of("myAccount", "http://gobbledygook"));
+		System.out.println(mapper.writeValueAsString(save));
+
 		save = SavedImage.withId("4321nonrandom").withQuality(90).toAzure(AzureLocation.of("myAccount", "http://gobbledygook"));
 		System.out.println(mapper.writeValueAsString(save));
 


### PR DESCRIPTION
Fixes issue #8 by creating a generic map of extra parameters that can be provided to `SavedImage`.

For the future: I think most of the other parameters should use this same methodology, with perhaps some built-in convenience methods in the `Builder`. In addition, the `SavedImage` constructors should be private (and should only include the required items, not the optional ones) so that everything is done via the builder, and so future changes and additional properties are not so disruptive.
